### PR TITLE
adding booz allen. they also work in El Segundo

### DIFF
--- a/companies.md
+++ b/companies.md
@@ -45,6 +45,7 @@ permalink: /companies/
 
 ## Remote Offices
 * [Blackberry](https://www.cylance.com/en-us/index.html) (formerly Cylance)
+* [Booz Allen Hamilton](https://www.boozallen.com/)
 * [Netflix](https://www.netflix.com/)
 * [Northrup Grumman](https://www.northropgrumman.com/Pages/default.aspx)
 * [Mantech](https://www.mantech.com/)


### PR DESCRIPTION
Last I checked Booz Allen had two different offices blocks away from each other.  That might not be the case anymore.  At any rate, they're still down in El Segundo working with LA AFB stuff.  